### PR TITLE
Fix millisecond formatting.

### DIFF
--- a/custom_components/coct_loadshedding/coct_interface.py
+++ b/custom_components/coct_loadshedding/coct_interface.py
@@ -168,7 +168,7 @@ class coct_interface:
         except Exception as e:
             _LOGGER.error(e, exc_info=True) # log exception info at ERROR log level
         try:
-            last_updated = datetime.datetime.strptime(json[0]['lastUpdated'], '%Y-%m-%dT%H:%M:%S.000Z')
+            last_updated = datetime.datetime.strptime(json[0]['lastUpdated'], '%Y-%m-%dT%H:%M:%S.%fZ')
         except Exception as e:
             _LOGGER.error(e, exc_info=True) # log exception info at ERROR log level
 
@@ -197,7 +197,7 @@ class coct_interface:
                     today_slots_hours.append(getTimeSlotHour(s))
             except Exception as e:
                 _LOGGER.error(e, exc_info=True) # log exception info at ERROR log level
-            try:                    
+            try:
                 # Grab tomorrow's times
                 tomorrow_date = datetime.datetime.now() + datetime.timedelta(1) # +1 day
                 ## First slots


### PR DESCRIPTION
I have been seeing the following error in my HA logs so I thought that I would create a fix for it:

```
time data '2023-06-04T07:35:28.366Z' does not match format '%Y-%m-%dT%H:%M:%S.000Z'
time data '2023-06-04T13:18:28.388Z' does not match format '%Y-%m-%dT%H:%M:%S.000Z'
time data '2023-06-04T13:25:28.339Z' does not match format '%Y-%m-%dT%H:%M:%S.000Z'
time data '2023-06-04T14:00:28.574Z' does not match format '%Y-%m-%dT%H:%M:%S.000Z'
time data '2023-06-05T03:00:28.346Z' does not match format '%Y-%m-%dT%H:%M:%S.000Z'
Traceback (most recent call last):
  File "/config/custom_components/coct_loadshedding/coct_interface.py", line 171, in async_get_data
    last_updated = datetime.datetime.strptime(json[0]['lastUpdated'], '%Y-%m-%dT%H:%M:%S.000Z')
  File "/usr/local/lib/python3.10/_strptime.py", line 568, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "/usr/local/lib/python3.10/_strptime.py", line 349, in _strptime
    raise ValueError("time data %r does not match format %r" %
ValueError: time data '2023-06-02T03:00:28.334Z' does not match format '%Y-%m-%dT%H:%M:%S.000Z'
```